### PR TITLE
Add Chrome no-sandbox flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Kemudian jalankan:
 docker run --rm rpabuddy --url https://contoh.com --selector "h1"
 ```
 
+Browser Chromium dalam container memerlukan flag `--no-sandbox`. Skrip sudah
+menambahkan flag ini secara otomatis, tetapi pastikan Anda tetap
+menggunakannya bila menyesuaikan konfigurasi.
+
 ## Docker Compose
 
 Jika Anda lebih suka menggunakan Docker Compose, file `docker-compose.yml`

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -14,6 +14,7 @@ def scrape(url: str, selector: str) -> List[str]:
     """Open the web page and return texts matching CSS selector."""
     options = Options()
     options.add_argument("--headless")
+    options.add_argument("--no-sandbox")
     user_data_dir = tempfile.mkdtemp(prefix="selenium-")
     options.add_argument(f"--user-data-dir={user_data_dir}")
     driver = webdriver.Chrome(options=options)


### PR DESCRIPTION
## Summary
- include `--no-sandbox` when configuring Chrome
- document this flag in the Docker section of the README

## Testing
- `python -m py_compile src/scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68582b542ca8832d8b2a7d072d63a937