### PR TITLE
Add CLI option for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ python src/scraper.py --url https://contoh.com --selector "h1"
 
 Skrip akan membuka halaman menggunakan Selenium dan menampilkan teks dari elemen yang sesuai dengan selector.
 
+### Login
+
+Anda dapat menjalankan proses login mandiri dengan opsi `--login` dan parameter terkait:
+
+```bash
+python src/scraper.py --login \
+  --url https://contoh.com/login \
+  --username nama_pengguna \
+  --password kata_sandi \
+  --username-selector nama-class \
+  --password-selector sandi-class \
+  --submit-selector tombol-id
+```
+
+Perintah di atas hanya menguji proses login dan akan menampilkan pesan `Login berhasil` atau `Login gagal`.
+
 
 ## Docker
 

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -68,8 +68,41 @@ def login(
 def main() -> None:
     parser = argparse.ArgumentParser(description="RPA web scraper")
     parser.add_argument("--url", required=True, help="Target URL")
-    parser.add_argument("--selector", required=True, help="CSS selector to extract")
+    parser.add_argument("--selector", help="CSS selector to extract")
+
+    parser.add_argument("--login", action="store_true", help="Run login flow")
+    parser.add_argument("--username", help="Username for login")
+    parser.add_argument("--password", help="Password for login")
+    parser.add_argument("--username-selector", help="Class for username field")
+    parser.add_argument("--password-selector", help="Class for password field")
+    parser.add_argument("--submit-selector", help="ID for submit button")
+
     args = parser.parse_args()
+
+    if args.login:
+        required = [
+            args.username,
+            args.password,
+            args.username_selector,
+            args.password_selector,
+            args.submit_selector,
+        ]
+        if not all(required):
+            parser.error("login requires username, password, and element selectors")
+
+        success = login(
+            args.url,
+            args.username,
+            args.password,
+            args.username_selector,
+            args.password_selector,
+            args.submit_selector,
+        )
+        print("Login berhasil" if success else "Login gagal")
+        return
+
+    if not args.selector:
+        parser.error("--selector is required unless --login is specified")
 
     results = scrape(args.url, args.selector)
     for text in results:


### PR DESCRIPTION
## Summary
- enable running login flow via `--login` flag
- document login usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859619269d4832d91b567be8132b3c0