### PR TITLE
Add config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,33 @@ Skrip akan membuka halaman menggunakan Selenium dan menampilkan teks dari elemen
 
 ### Login
 
-Anda dapat menjalankan proses login mandiri dengan opsi `--login` dan parameter terkait:
+Anda dapat menjalankan proses login mandiri dengan opsi `--login` dan parameter terkait. Kredensial juga dapat disimpan dalam berkas konfigurasi JSON dengan opsi `--config`:
 
 ```bash
 python src/scraper.py --login \
   --url https://contoh.com/login \
   --username nama_pengguna \
   --password kata_sandi \
+  --username-selector nama-class \
+  --password-selector sandi-class \
+  --submit-selector tombol-id
+```
+
+Atau simpan kredensial ke dalam berkas `config.json`:
+
+```json
+{
+  "username": "nama_pengguna",
+  "password": "kata_sandi"
+}
+```
+
+Kemudian jalankan:
+
+```bash
+python src/scraper.py --login \
+  --url https://contoh.com/login \
+  --config config.json \
   --username-selector nama-class \
   --password-selector sandi-class \
   --submit-selector tombol-id
@@ -51,6 +71,8 @@ python src/scraper.py --advanced-search \
   --password-selector sandi-class \
   --submit-selector tombol-id
 ```
+
+Anda juga dapat menggunakan berkas konfigurasi dengan opsi `--config`.
 
 Skrip akan masuk ke aplikasi kemudian membuka halaman **Advanced Search**,
 memilih produk *Company*, memilih seluruh komponen serta semua nilai pada
@@ -76,8 +98,7 @@ Untuk menjalankan proses login di dalam container, gunakan:
 ```bash
 docker run --rm rpabuddy --login \
   --url https://contoh.com/login \
-  --username nama_pengguna \
-  --password kata_sandi \
+  --config config.json \
   --username-selector nama-class \
   --password-selector sandi-class \
   --submit-selector tombol-id
@@ -103,8 +124,7 @@ Untuk login menggunakan Docker Compose:
 docker compose build
 docker compose run rpabuddy --login \
   --url https://contoh.com/login \
-  --username nama_pengguna \
-  --password kata_sandi \
+  --config config.json \
   --username-selector nama-class \
   --password-selector sandi-class \
   --submit-selector tombol-id

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -1,6 +1,7 @@
 """Simple RPA-based web scraper."""
 
 import argparse
+import json
 import logging
 import shutil
 import tempfile
@@ -189,11 +190,25 @@ def main() -> None:
     )
     parser.add_argument("--username", help="Username for login")
     parser.add_argument("--password", help="Password for login")
+    parser.add_argument(
+        "--config",
+        help="Path to JSON config file containing username and password",
+    )
     parser.add_argument("--username-selector", help="Class for username field")
     parser.add_argument("--password-selector", help="Class for password field")
     parser.add_argument("--submit-selector", help="ID for submit button")
 
     args = parser.parse_args()
+
+    if args.config:
+        try:
+            with open(args.config, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+        except FileNotFoundError:
+            parser.error(f"Config file {args.config} not found")
+
+        args.username = args.username or cfg.get("username")
+        args.password = args.password or cfg.get("password")
 
     if args.advanced_search:
         required = [


### PR DESCRIPTION
## Summary
- allow reading username and password from a JSON config file via `--config`
- document usage of config file in README

## Testing
- `python -m py_compile src/scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_685cfc61d500832d88891863732d6432