### PR TITLE
Fix advanced search page detection

### DIFF
--- a/src/scraper.py
+++ b/src/scraper.py
@@ -169,7 +169,7 @@ def login_and_advanced_search(
             WebDriverWait(driver, 10).until(EC.url_contains("query.cgi"))
 
             logger.info("Switching to advanced search")
-            driver.get("https://contoh.com/query.cgi?format=specific")
+            driver.get("https://contoh.com/query.cgi?format=advanced")
             try:
                 WebDriverWait(driver, 10).until(
                     EC.presence_of_element_located(


### PR DESCRIPTION
## Summary
- use the `format=advanced` URL when opening Bugzilla's advanced search page

## Testing
- `python -m py_compile src/scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_685d14ffddb4832d8ee3231fcda68f41