### PR TITLE
Implement CSV export for advanced search

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ python src/scraper.py --advanced-search \
   --password kata_sandi \
   --username-selector nama-class \
   --password-selector sandi-class \
-  --submit-selector tombol-id
+  --submit-selector tombol-id \
+  --csv-output hasil.csv
 ```
 
 Anda juga dapat menggunakan berkas konfigurasi dengan opsi `--config`.
@@ -77,6 +78,8 @@ Anda juga dapat menggunakan berkas konfigurasi dengan opsi `--config`.
 Skrip akan masuk ke aplikasi kemudian membuka halaman **Advanced Search**,
 memilih produk *Company*, memilih seluruh komponen serta semua nilai pada
 **Status** dan **Resolution**, lalu menekan tombol **Search**.
+Jika opsi `--csv-output` diberikan, hasil pencarian akan disimpan ke berkas
+CSV tersebut.
 
 
 ## Docker


### PR DESCRIPTION
## Summary
- support downloading search results as CSV when performing advanced search
- document new `--csv-output` option in README

## Testing
- `python -m py_compile src/scraper.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685d1c688570832d8f3b250c12cebbbf